### PR TITLE
CI: Push Docker image to GHCR on master merges

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,8 +11,31 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build the Docker image
+
+    - name: Log in to the Container registry
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:${{ github.sha }}
+          ghcr.io/${{ github.repository }}:latest
+
+    - name: Build the Docker image for pull requests
+      if: github.event_name == 'pull_request'
       run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to:
- Log in to GHCR.
- Build and push the Docker image to GHCR when changes are merged to the master branch.
- Tag the image with the Git SHA and 'latest'.
- For pull requests, the workflow will only build the image without pushing.